### PR TITLE
Changed 'AzureSubscription' to: 'Select-AzSubscription'

### DIFF
--- a/Create-VMBackupPolicy.ps1
+++ b/Create-VMBackupPolicy.ps1
@@ -48,7 +48,7 @@ $subscriptions = Get-AzSubscription | ? State -eq 'Enabled'
 
 foreach ($sub in $subscriptions) {
 
-    Select-AzureSubscription -SubscriptionObject $sub
+    Select-AzSubscription -SubscriptionObject $sub
 
     foreach ($vault in (Get-AzRecoveryServicesVault)) {
 


### PR DESCRIPTION
Updated, Changed 'AzureSubscription' to: 'Select-AzSubscription'.

Select-AzureSubscription - not a valid Az cmdlet.